### PR TITLE
Make build script handling more flexible 

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
     // this is necessary for the automatic typing of the adapter config
     "resolveJsonModule": true,
 
+    // Avoid conflicts with line endings in compiled files
+    "newLine": "lf",
+
     // Set this to false if you want to disable the very strict rules (not recommended)
     "strict": true,
     // Or enable some of those features for more fine-grained control


### PR DESCRIPTION
This PR makes the build script handling a bit more flexible than it currently is. In detail:
* Accept `watch:react` script as an alternative to `watch:parcel` (I want to get rid of parcel some time in the future)
* Use RegExp to detect the first successful build

I've also edited tsconfig to force LF in the generated files.