### PR TITLE
Add ability to debug JS-Controller

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -873,7 +873,7 @@ class DevServer {
         const filename = this.getExecSyncOutput('npm pack', this.rootDir).trim();
         this.log.info(`Packed to ${filename}`);
         const fullPath = path.join(this.rootDir, filename);
-        this.execSync(`npm install --no-save "${fullPath}"`, this.profileDir);
+        this.execSync(`npm install "${fullPath}"`, this.profileDir);
         await this.rimraf(fullPath);
     }
     async installRepoAdapter(adapterName) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -85,7 +85,7 @@ class DevServer {
                 description: 'Provide an ioBroker backup file to restore in this dev-server',
             },
             force: { type: 'boolean', hidden: true },
-        }, async (args) => await this.setup(args.adminPort, { jsController: args.jsController, admin: args.admin }, args.backupFile, !!args.force))
+        }, async (args) => await this.setup(args.adminPort, { ['iobroker.js-controller']: args.jsController, ['iobroker.admin']: args.admin }, args.backupFile, !!args.force))
             .command(['update [profile]', 'ud'], 'Update ioBroker and its dependencies to the latest versions', {}, async () => await this.update())
             .command(['run [profile]', 'r'], 'Run ioBroker dev-server, the adapter will not run, but you may test the Admin UI with hot-reload', {}, async () => await this.run())
             .command(['watch [profile]', 'w'], 'Run ioBroker dev-server and start the adapter in "watch" mode. The adapter will automatically restart when its source code changes. You may attach a debugger to the running adapter.', {}, async () => await this.watch())
@@ -796,7 +796,7 @@ class DevServer {
         // create the package file
         if (this.isJSController()) {
             // if this dev-server is used to debug JS-Controller, don't install a published version
-            delete dependencies.jsController;
+            delete dependencies['iobroker.js-controller'];
         }
         const pkg = {
             name: `dev-server.${this.adapterName}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -263,7 +263,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -1034,6 +1038,16 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "blob": {
       "version": "0.0.5",
@@ -2690,6 +2704,13 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3723,6 +3744,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,10 +49,8 @@ interface DevServerConfig {
   adminPort: number;
 }
 
-interface DependencyVersions {
-  jsController?: string;
-  admin: string;
-}
+type CoreDependency = 'iobroker.js-controller' | 'iobroker.admin';
+type DependencyVersions = Partial<Record<CoreDependency, string>>;
 
 class DevServer {
   private readonly log = new Logger();
@@ -99,7 +97,7 @@ class DevServer {
         async (args) =>
           await this.setup(
             args.adminPort,
-            { jsController: args.jsController, admin: args.admin },
+            { ['iobroker.js-controller']: args.jsController, ['iobroker.admin']: args.admin },
             args.backupFile,
             !!args.force,
           ),
@@ -947,7 +945,7 @@ class DevServer {
     // create the package file
     if (this.isJSController()) {
       // if this dev-server is used to debug JS-Controller, don't install a published version
-      delete dependencies.jsController;
+      delete dependencies['iobroker.js-controller'];
     }
     const pkg = {
       name: `dev-server.${this.adapterName}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1042,7 +1042,7 @@ class DevServer {
     this.log.info(`Packed to ${filename}`);
 
     const fullPath = path.join(this.rootDir, filename);
-    this.execSync(`npm install --no-save "${fullPath}"`, this.profileDir);
+    this.execSync(`npm install "${fullPath}"`, this.profileDir);
 
     await this.rimraf(fullPath);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ interface DevServerConfig {
 }
 
 interface DependencyVersions {
-  jsController: string;
+  jsController?: string;
   admin: string;
 }
 
@@ -277,6 +277,10 @@ class DevServer {
     }
   }
 
+  private isJSController(): boolean {
+    return this.adapterName === 'js-controller';
+  }
+
   private readPackageJson(): Promise<any> {
     return readJson(path.join(this.rootDir, 'package.json'));
   }
@@ -321,7 +325,7 @@ class DevServer {
     this.uploadAdapter('admin');
 
     await this.installLocalAdapter();
-    this.uploadAdapter(this.adapterName);
+    if (!this.isJSController()) this.uploadAdapter(this.adapterName);
 
     this.log.box(`dev-server was sucessfully updated.`);
   }
@@ -335,21 +339,21 @@ class DevServer {
     this.checkSetup();
     await this.installLocalAdapter();
     await this.startServer();
-    await this.startAdapterWatch();
+    if (!this.isJSController()) await this.startAdapterWatch();
   }
 
   async debug(wait: boolean): Promise<void> {
     this.checkSetup();
     await this.installLocalAdapter();
-    await this.copySourcemaps();
+    if (!this.isJSController()) await this.copySourcemaps();
     await this.startServer();
-    await this.startAdapterDebug(wait);
+    if (!this.isJSController()) await this.startAdapterDebug(wait);
   }
 
   async upload(): Promise<void> {
     this.checkSetup();
     await this.installLocalAdapter();
-    this.uploadAdapter(this.adapterName);
+    if (!this.isJSController()) this.uploadAdapter(this.adapterName);
 
     this.log.box(`The latest content of iobroker.${this.adapterName} was uploaded to ${this.profileDir}.`);
   }
@@ -429,22 +433,28 @@ class DevServer {
       throw new Error(`Couldn't find dev-server configuration in package.json`);
     }
 
-    const proc = this.spawn('node', ['node_modules/iobroker.js-controller/controller.js'], this.profileDir);
+    const nodeArgs = ['node_modules/iobroker.js-controller/controller.js'];
+    if (this.isJSController()) {
+      nodeArgs.unshift('--inspect');
+    }
+    const proc = this.spawn('node', nodeArgs, this.profileDir);
     proc.on('exit', (code) => {
       console.error(chalk.yellow(`ioBroker controller exited with code ${code}`));
       process.exit(-1);
     });
 
     // figure out if we need parcel (React)
-    const pkg = await this.readPackageJson();
-    const scripts = pkg.scripts;
-    if (scripts) {
-      if (scripts['watch:react']) {
-        // use React with default script name
-        await this.startReact();
-      } else if (scripts['watch:parcel']) {
-        // use React with legacy script name
-        await this.startReact('watch:parcel');
+    if (!this.isJSController()) {
+      const pkg = await this.readPackageJson();
+      const scripts = pkg.scripts;
+      if (scripts) {
+        if (scripts['watch:react']) {
+          // use React with default script name
+          await this.startReact();
+        } else if (scripts['watch:parcel']) {
+          // use React with legacy script name
+          await this.startReact('watch:parcel');
+        }
       }
     }
 
@@ -935,14 +945,15 @@ class DevServer {
     await writeJson(path.join(dataDir, 'iobroker.json'), config, { spaces: 2 });
 
     // create the package file
+    if (this.isJSController()) {
+      // if this dev-server is used to debug JS-Controller, don't install a published version
+      delete dependencies.jsController;
+    }
     const pkg = {
       name: `dev-server.${this.adapterName}`,
       version: '1.0.0',
       private: true,
-      dependencies: {
-        'iobroker.js-controller': dependencies.jsController,
-        'iobroker.admin': dependencies.admin,
-      },
+      dependencies,
       'dev-server': {
         adminPort: adminPort,
       },
@@ -958,6 +969,10 @@ class DevServer {
       this.execSync(`${IOBROKER_COMMAND} restore "${fullPath}"`, this.profileDir);
     }
 
+    if (this.isJSController()) {
+      await this.installLocalAdapter();
+    }
+
     this.uploadAndAddAdapter('admin');
 
     // reconfigure admin instance (only listen to local IP address)
@@ -967,27 +982,29 @@ class DevServer {
       this.profileDir,
     );
 
-    // install local adapter
-    await this.installLocalAdapter();
-    this.uploadAndAddAdapter(this.adapterName);
+    if (!this.isJSController()) {
+      // install local adapter
+      await this.installLocalAdapter();
+      this.uploadAndAddAdapter(this.adapterName);
 
-    // installing any dependencies
-    const { common } = await readJson(path.join(this.rootDir, 'io-package.json'));
-    const adapterDeps = [
-      ...this.getDependencies(common.dependencies),
-      ...this.getDependencies(common.globalDependencies),
-    ];
-    this.log.debug(`Found ${adapterDeps.length} adapter dependencies`);
-    for (const adapter of adapterDeps) {
-      try {
-        await this.installRepoAdapter(adapter);
-      } catch (error) {
-        this.log.debug(`Couldn't install iobroker.${adapter}: ${error}`);
+      // installing any dependencies
+      const { common } = await readJson(path.join(this.rootDir, 'io-package.json'));
+      const adapterDeps = [
+        ...this.getDependencies(common.dependencies),
+        ...this.getDependencies(common.globalDependencies),
+      ];
+      this.log.debug(`Found ${adapterDeps.length} adapter dependencies`);
+      for (const adapter of adapterDeps) {
+        try {
+          await this.installRepoAdapter(adapter);
+        } catch (error) {
+          this.log.debug(`Couldn't install iobroker.${adapter}: ${error}`);
+        }
       }
-    }
 
-    this.log.notice(`Stop ${this.adapterName}.0`);
-    this.execSync(`${IOBROKER_COMMAND} stop ${this.adapterName} 0`, this.profileDir);
+      this.log.notice(`Stop ${this.adapterName}.0`);
+      this.execSync(`${IOBROKER_COMMAND} stop ${this.adapterName} 0`, this.profileDir);
+    }
 
     this.log.notice('Disable statistics reporting');
     this.execSync(`${IOBROKER_COMMAND} object set system.config common.diag="none"`, this.profileDir);


### PR DESCRIPTION
This is a first draft at debugging js-controller itself with dev-server. However I seem to be missing something - my installation ends up without a JS-Controller, although it got installed:

<details>
<summary>Log of JS-Controller installation</summary>

```
C:\Repositories\ioBroker.js-controller\.dev-server\default> npm install --no-save "C:\Repositories\ioBroker.js-controller\iobroker.js-controller-3.3.7.tgz"
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
npm WARN deprecated har-validator@5.1.5: this library is no longer supported

> iobroker.js-controller@3.3.7 preinstall C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\iobroker.js-controller
> node lib/preinstallCheck.js

NPM version: 6.14.13

> unix-dgram@2.0.3 install C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\unix-dgram
> node-gyp rebuild


C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\unix-dgram>if not defined npm_config_node_gyp (node "C:\Users\domin\AppData\Roaming\npm\node_modules\npm\node_modules\npm-lifecycle\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" rebuild )  else (node "C:\Users\domin\AppData\Roaming\npm\node_modules\npm\node_modules\node-gyp\bin\node-gyp.js" rebuild )
Die Projekte in dieser Projektmappe werden nacheinander erstellt. Um eine parallele Erstellung zu ermöglichen, müssen Sie den Schalter "/m" hinzufügen.
  unix_dgram.cc
  win_delay_load_hook.cc
..\src\unix_dgram.cc(9): fatal error C1083: Cannot open include file: 'unistd.h': No such file or directory [C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\unix-dgram\build\unix_dgram.vcxp
roj]
←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mbuild error←[0m
←[0m←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mstack←[0m Error: `C:\Program Files (x86)\MSBuild\14.0\bin\MSBuild.exe` failed with exit code: 1
←[0m←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mstack←[0m     at ChildProcess.onExit (C:\Users\domin\AppData\Roaming\npm\node_modules\npm\node_modules\node-gyp\lib\build.js:194:23)
←[0m←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mstack←[0m     at ChildProcess.emit (events.js:314:20)
←[0m←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mstack←[0m     at Process.ChildProcess._handle.onexit (internal/child_process.js:276:12)
←[0m←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mSystem←[0m Windows_NT 10.0.19041
←[0m←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mcommand←[0m "C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\domin\\AppData\\Roaming\\npm\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
←[0m←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mcwd←[0m C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\unix-dgram
←[0m←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mnode -v←[0m v12.22.1
←[0m←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mnode-gyp -v←[0m v5.1.0
←[0m←[37;40mgyp←[0m ←[0m←[31;40mERR!←[0m ←[0m←[35mnot ok←[0m
←[0m
> ursa-optional@0.9.10 install C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\ursa-optional
> node rebuild.js

ursaNative bindings compilation fail. This is not an issue. Modules that depend on it will use fallbacks.

> diskusage@1.1.3 install C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\diskusage
> node-gyp rebuild


C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\diskusage>if not defined npm_config_node_gyp (node "C:\Users\domin\AppData\Roaming\npm\node_modules\npm\node_modules\npm-lifecycle\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" rebuild )  else (node "C:\Users\domin\AppData\Roaming\npm\node_modules\npm\node_modules\node-gyp\bin\node-gyp.js" rebuild )
Die Projekte in dieser Projektmappe werden nacheinander erstellt. Um eine parallele Erstellung zu ermöglichen, müssen Sie den Schalter "/m" hinzufügen.
  main.cpp
  diskusage_win.cpp
  win_delay_load_hook.cc
     Creating library C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\diskusage\build\Release\diskusage.lib and object C:\Repositories\ioBroker.js-controller\.dev-server\default\node_module
  s\diskusage\build\Release\diskusage.exp
  diskusage.vcxproj -> C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\diskusage\build\Release\\diskusage.node
  diskusage.vcxproj -> C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\diskusage\build\Release\diskusage.pdb (Full PDB)

> iobroker.js-controller@3.3.7 install C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\iobroker.js-controller
> node iobroker.js setup first

Server Cannot load C:\Repositories\ioBroker.js-controller\.dev-server\default\iobroker-data\objects.json: Database file C:\Repositories\ioBroker.js-controller\.dev-server\default\iobroker-data\objects.json does not exists.. We try last Backup!
Server Cannot load C:\Repositories\ioBroker.js-controller\.dev-server\default\iobroker-data\states.json: Database file C:\Repositories\ioBroker.js-controller\.dev-server\default\iobroker-data\states.json does not exists.. We try last Backup!
Server Cannot load C:\Repositories\ioBroker.js-controller\.dev-server\default\iobroker-data\objects.json.bak: Database file C:\Repositories\ioBroker.js-controller\.dev-server\default\iobroker-data\objects.json.bak
does not exists.. Continue with empty dataset!
Server If this is no Migration or initial start please restore the last backup from C:\Repositories\ioBroker.js-controller\.dev-server\default\iobroker-data\backup-objects
Server Cannot load C:\Repositories\ioBroker.js-controller\.dev-server\default\iobroker-data\states.json.bak: Database file C:\Repositories\ioBroker.js-controller\.dev-server\default\iobroker-data\states.json.bak does not exists.. Continue with empty dataset!
Server If this is no Migration or initial start please restore the last backup from C:\Repositories\ioBroker.js-controller\.dev-server\default\iobroker-data\backup-objects
 Cannot read system.config: null (OK when migrating or restoring)
object 0_userdata.0.example_state created
object 0_userdata.0 created
object alias.0 created
object system.certificates created
object system.repositories created
object system.config created
object enum.functions created
object enum.rooms created
object system.group.user created
object system.group.administrator created
object _design/system created
object system.meta.uuid created: e8e53c8d-9165-5f86-5482-04ebf3f0c472
object system.user.admin created

ATTENTION: Error reporting via Sentry will be activated on next start of ioBroker

ioBroker wants to make sure to deliver the most stable smart home system.
To allow this we decided to implement an automatic error and crash reporting solution into the js-controller and also into adapters.

THIS REPORTING WILL BE ENABLED WITH THE NEXT START OF YOUR IOBROKER!

For any error that leads to the crash of the js-controller or one of the relevant adapters the error details are send to a server. For the js-controller and core adapters this server is located and operated in germany. For community adapters please check the Github Readme of the affected adapter for details which Sentry server is used.

If you want to disable the error reporting you can use the command
'iobroker plugin disable sentry'
This command will also make sure that no adapter that runs on this host will send crash reporting data to sentry.


Renamed repository "default to "stable"
Renamed repository "latest to "beta"

> @root/acme@3.1.0 postinstall C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\@root\acme
> node scripts/postinstall


> esbuild@0.11.20 postinstall C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\esbuild
> node install.js

npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@~2.3.1 (node_modules\chokidar\node_modules\fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"win32","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: unix-dgram@2.0.3 (node_modules\unix-dgram):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: unix-dgram@2.0.3 install: `node-gyp rebuild`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1

+ iobroker.js-controller@3.3.7
added 313 packages from 251 contributors and audited 72 packages in 40.044s

15 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

</details>

The followup upload of admin then fails, but it works when it's installed by ioBroker with `add`:

<details>
<summary>Log of uploading/installing admin</summary>

```
Upload iobroker.admin
C:\Repositories\ioBroker.js-controller\.dev-server\default> node node_modules/iobroker.js-controller/iobroker.js upload admin
No alive host found which has the adapter admin installed! No upload possible. Skipped.
C:\Repositories\ioBroker.js-controller\.dev-server\default> node node_modules/iobroker.js-controller/iobroker.js list instances
Add admin.0
C:\Repositories\ioBroker.js-controller\.dev-server\default> node node_modules/iobroker.js-controller/iobroker.js add admin 0
Update repository "stable" under "http://download.iobroker.net/sources-dist.json"
hash changed or no sources cached => force download of new sources
NPM version: 6.14.13
Installing iobroker.admin@4.2.1... (System call)
+ iobroker.admin@4.2.1
added 55 packages from 80 contributors, removed 263 packages, updated 1 package, moved 3 packages and audited 177 packages in 6.986s
found 0 vulnerabilities

host.dev-js-controller-DESKTOP-OCULUR0 install adapter admin
upload [3] admin.admin C:/Repositories/ioBroker.js-controller/.dev-server/default/node_modules/iobroker.admin/admin/words.js words.js application/javascript
upload [2] admin.admin C:/Repositories/ioBroker.js-controller/.dev-server/default/node_modules/iobroker.admin/admin/index_m.html index_m.html text/html
upload [1] admin.admin C:/Repositories/ioBroker.js-controller/.dev-server/default/node_modules/iobroker.admin/admin/index.html index.html text/html
upload [0] admin.admin C:/Repositories/ioBroker.js-controller/.dev-server/default/node_modules/iobroker.admin/admin/admin.png admin.png image/png
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin created/updated
host.dev-js-controller-DESKTOP-OCULUR0 create instance admin
host.dev-js-controller-DESKTOP-OCULUR0 object admin.0.info.newsETag created
host.dev-js-controller-DESKTOP-OCULUR0 object admin.0.info.newsfeed created
host.dev-js-controller-DESKTOP-OCULUR0 object admin.0.connected created
host.dev-js-controller-DESKTOP-OCULUR0 object admin.0 created
host.dev-js-controller-DESKTOP-OCULUR0 object admin.0.info created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.upload created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.logLevel created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.sigKill created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.eventLoopLag created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.outputCount created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.inputCount created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.uptime created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.memRss created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.memHeapTotal created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.memHeapUsed created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.cputime created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.cpu created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.compactMode created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.connected created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0.alive created
host.dev-js-controller-DESKTOP-OCULUR0 object system.adapter.admin.0 created
```

</details>

but configuring the instance fails again (missing JS-Controller):
<details>
<summary>Log of Configuring admin</summary>

```
Configure admin.0
C:\Repositories\ioBroker.js-controller\.dev-server\default> node node_modules/iobroker.js-controller/iobroker.js set admin.0 --port 22344 --bind 127.0.0.1
internal/modules/cjs/loader.js:818
  throw err;
  ^

Error: Cannot find module 'C:\Repositories\ioBroker.js-controller\.dev-server\default\node_modules\iobroker.js-controller\iobroker.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
index.js setup [profile]

Set up dev-server in the current directory. This should always be called in the directory where the
io-package.json file of your adapter is located.

Optionen:
      --version       Version anzeigen                                                     [boolean]
  -t, --temp          Temporary directory where the dev-server data will be located
                                                                  [string] [Standard: ".dev-server"]
      --help          Hilfe anzeigen                                                       [boolean]
  -p, --adminPort     TCP port on which ioBroker.admin will be available     [Zahl] [Standard: 8081]
  -j, --jsController  Define which version of js-controller to be used [string] [Standard: "latest"]
  -a, --admin         Define which version of admin to be used         [string] [Standard: "latest"]
  -b, --backupFile    Provide an ioBroker backup file to restore in this dev-server         [string]

Error: Command failed: node node_modules/iobroker.js-controller/iobroker.js set admin.0 --port 22344 --bind 127.0.0.1
    at checkExecSyncError (child_process.js:635:11)
    at Object.execSync (child_process.js:671:15)
    at DevServer.execSync (C:\Repositories\dev-server\dist\index.js:916:19)
    at DevServer.setupDevServer (C:\Repositories\dev-server\dist\index.js:824:14)
    at async DevServer.setup (C:\Repositories\dev-server\dist\index.js:238:9)
    at async Object.handler (C:\Repositories\dev-server\dist\index.js:88:28) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 17896,
  stdout: null,
  stderr: null
}
```

</details>