### PR TITLE
Ignoring all node_modules directories, not only in the project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+
+- (UncleSamSwiss) Fixed warnings when debugging "old-style" React adapters like ioBroker.javascript
+
 ## 0.4.0 (2021-07-06)
 
 - (UncleSamSwiss) Changed default log level to `debug` and adapter repo to `beta` (#74)

--- a/dist/index.js
+++ b/dist/index.js
@@ -552,7 +552,7 @@ class DevServer {
         const exts = typeof extensions === 'string' ? [extensions] : extensions;
         const patterns = exts.map((e) => `./**/*.${e}`);
         patterns.push('!./.*/**');
-        patterns.push('!./node_modules/**');
+        patterns.push('!./**/node_modules/**');
         patterns.push('!./test/**');
         if (excludeAdmin) {
             patterns.push('!./admin/**');

--- a/dist/index.js
+++ b/dist/index.js
@@ -30,7 +30,6 @@ const chalk_1 = require("chalk");
 const cp = __importStar(require("child_process"));
 const chokidar_1 = __importDefault(require("chokidar"));
 const enquirer_1 = require("enquirer");
-const escape_string_regexp_1 = __importDefault(require("escape-string-regexp"));
 const express_1 = __importDefault(require("express"));
 const fast_glob_1 = __importDefault(require("fast-glob"));
 const fs_extra_1 = require("fs-extra");
@@ -975,7 +974,7 @@ class DevServer {
         if (!relative.endsWith('/')) {
             relative += '/';
         }
-        const tempDirRegex = new RegExp(`\\s${(0, escape_string_regexp_1.default)(relative)
+        const tempDirRegex = new RegExp(`\\s${this.escapeStringRegexp(relative)
             .replace(/[\\/]$/, '')
             .replace(/(\\\\|\/)/g, '[\\/]')}`);
         const verifyFile = async (filename, command, allowStar) => {
@@ -1162,6 +1161,11 @@ class DevServer {
     }
     rimraf(name) {
         return new Promise((resolve, reject) => rimraf(name, (err) => (err ? reject(err) : resolve())));
+    }
+    escapeStringRegexp(value) {
+        // Escape characters with special meaning either inside or outside character sets.
+        // Use a simple backslash escape when it’s always valid, and a `\xnn` escape when the simpler form would be disallowed by Unicode patterns’ stricter grammar.
+        return value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
     }
     async exit(exitCode) {
         const childPids = this.childProcesses.map((p) => p.pid).filter((p) => !!p);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2185,11 +2185,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
-    "escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-    },
     "escodegen": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
     "enquirer": "^2.3.6",
-    "escape-string-regexp": "^5.0.0",
     "express": "^4.17.1",
     "fast-glob": "^3.2.7",
     "fs-extra": "^10.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import { bold, gray, yellow } from 'chalk';
 import * as cp from 'child_process';
 import chokidar from 'chokidar';
 import { prompt } from 'enquirer';
-import escapeStringRegexp from 'escape-string-regexp';
 import express from 'express';
 import fg from 'fast-glob';
 import {
@@ -1152,7 +1151,7 @@ class DevServer {
       relative += '/';
     }
     const tempDirRegex = new RegExp(
-      `\\s${escapeStringRegexp(relative)
+      `\\s${this.escapeStringRegexp(relative)
         .replace(/[\\/]$/, '')
         .replace(/(\\\\|\/)/g, '[\\/]')}`,
     );
@@ -1359,6 +1358,12 @@ class DevServer {
 
   private rimraf(name: string): Promise<void> {
     return new Promise<void>((resolve, reject) => rimraf(name, (err) => (err ? reject(err) : resolve())));
+  }
+
+  private escapeStringRegexp(value: string): string {
+    // Escape characters with special meaning either inside or outside character sets.
+    // Use a simple backslash escape when it’s always valid, and a `\xnn` escape when the simpler form would be disallowed by Unicode patterns’ stricter grammar.
+    return value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/-/g, '\\x2d');
   }
 
   private async exit(exitCode: number): Promise<never> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -676,7 +676,7 @@ class DevServer {
     const exts = typeof extensions === 'string' ? [extensions] : extensions;
     const patterns = exts.map((e) => `./**/*.${e}`);
     patterns.push('!./.*/**');
-    patterns.push('!./node_modules/**');
+    patterns.push('!./**/node_modules/**');
     patterns.push('!./test/**');
     if (excludeAdmin) {
       patterns.push('!./admin/**');


### PR DESCRIPTION
This fixes warnings when debugging "old-style" React adapters like ioBroker.javascript

Fixes #115 