### PR TITLE
feat: symlink the local adapter instead of pack/install on each change

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -444,7 +444,12 @@ class DevServer {
         }
     }
     async startJsController() {
-        const proc = await this.spawn('node', ['--inspect=127.0.0.1:9228', '--preserve-symlinks', 'node_modules/iobroker.js-controller/controller.js'], this.profileDir);
+        const proc = await this.spawn('node', [
+            '--inspect=127.0.0.1:9228',
+            '--preserve-symlinks',
+            '--preserve-symlinks-main',
+            'node_modules/iobroker.js-controller/controller.js',
+        ], this.profileDir);
         proc.on('exit', async (code) => {
             console.error(chalk.yellow(`ioBroker controller exited with code ${code}`));
             return this.exit(-1, 'SIGKILL');
@@ -454,7 +459,11 @@ class DevServer {
     }
     async startJsControllerDebug(wait) {
         this.log.notice(`Starting debugger for ${this.adapterName}`);
-        const nodeArgs = ['node_modules/iobroker.js-controller/controller.js'];
+        const nodeArgs = [
+            '--preserve-symlinks',
+            '--preserve-symlinks-main',
+            'node_modules/iobroker.js-controller/controller.js',
+        ];
         if (wait) {
             nodeArgs.unshift('--inspect-brk');
         }
@@ -777,7 +786,7 @@ class DevServer {
     }
     async startAdapterDebug(wait) {
         this.log.notice(`Starting ioBroker adapter debugger for ${this.adapterName}.0`);
-        const args = [IOBROKER_CLI, 'debug', `${this.adapterName}.0`];
+        const args = ['--preserve-symlinks', '--preserve-symlinks-main', IOBROKER_CLI, 'debug', `${this.adapterName}.0`];
         if (wait) {
             args.push('--wait');
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -99,7 +99,7 @@ class DevServer {
                 type: 'boolean',
                 alias: 'l',
                 default: false,
-                description: 'Use symlinks instead of packing and installing the current adapter. Requires JS-Controller 5+ and npm 7+.',
+                description: 'Use symlinks instead of packing and installing the current adapter for a smoother dev experience. Requires JS-Controller 5+.',
             },
         }, async (args) => await this.setup(args.adminPort, { ['iobroker.js-controller']: args.jsController, ['iobroker.admin']: args.admin }, args.backupFile, !!args.force, args.symlinks))
             .command(['update [profile]', 'ud'], 'Update ioBroker and its dependencies to the latest versions', {}, async () => await this.update())

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@iobroker/testing": "^4.1.0",
         "acorn": "^8.8.1",
-        "axios": "^1.2.0",
+        "axios": "^1.3.2",
         "boxen": "^5.1.2",
         "browser-sync": "^2.27.10",
         "bs-html-injector": "^3.0.3",
@@ -1067,9 +1067,9 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "node_modules/axios": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.0.tgz",
-      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
+      "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -6539,9 +6539,9 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.0.tgz",
-      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
+      "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@iobroker/testing": "^4.1.0",
     "acorn": "^8.8.1",
-    "axios": "^1.2.0",
+    "axios": "^1.3.2",
     "boxen": "^5.1.2",
     "browser-sync": "^2.27.10",
     "bs-html-injector": "^3.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -542,7 +542,12 @@ class DevServer {
   async startJsController(): Promise<void> {
     const proc = await this.spawn(
       'node',
-      ['--inspect=127.0.0.1:9228', '--preserve-symlinks', 'node_modules/iobroker.js-controller/controller.js'],
+      [
+        '--inspect=127.0.0.1:9228',
+        '--preserve-symlinks',
+        '--preserve-symlinks-main',
+        'node_modules/iobroker.js-controller/controller.js',
+      ],
       this.profileDir,
     );
     proc.on('exit', async (code) => {
@@ -556,7 +561,11 @@ class DevServer {
   private async startJsControllerDebug(wait: boolean): Promise<void> {
     this.log.notice(`Starting debugger for ${this.adapterName}`);
 
-    const nodeArgs = ['node_modules/iobroker.js-controller/controller.js'];
+    const nodeArgs = [
+      '--preserve-symlinks',
+      '--preserve-symlinks-main',
+      'node_modules/iobroker.js-controller/controller.js',
+    ];
     if (wait) {
       nodeArgs.unshift('--inspect-brk');
     } else {
@@ -931,7 +940,7 @@ class DevServer {
 
   private async startAdapterDebug(wait: boolean): Promise<void> {
     this.log.notice(`Starting ioBroker adapter debugger for ${this.adapterName}.0`);
-    const args = [IOBROKER_CLI, 'debug', `${this.adapterName}.0`];
+    const args = ['--preserve-symlinks', '--preserve-symlinks-main', IOBROKER_CLI, 'debug', `${this.adapterName}.0`];
     if (wait) {
       args.push('--wait');
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ class DevServer {
             alias: 'l',
             default: false,
             description:
-              'Use symlinks instead of packing and installing the current adapter. Requires JS-Controller 5+ and npm 7+.',
+              'Use symlinks instead of packing and installing the current adapter for a smoother dev experience. Requires JS-Controller 5+.',
           },
         },
         async (args) =>


### PR DESCRIPTION
This PR will make it possible to work on adapter with less delay. Instead of packing the repo each time and manually syncing files, we instead configure npm to symlink the repo into node_modules.

This requires some changes in js-controller (https://github.com/ioBroker/ioBroker.js-controller/pull/2103), as well as a bit of fine-tuning because of sourcemaps/breakpoints.
Also we should make this opt in, at least until js-controller 5.