### PR TITLE
main as esm module when using type: commonjs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1201,7 +1201,8 @@ class DevServer {
             ignore: ignoreList,
             ignoreRoot: [],
             delay: 2000,
-            execMap: { js: 'node --inspect --preserve-symlinks --preserve-symlinks-main' },
+            execMap: { js: 'node --inspect --preserve-symlinks --preserve-symlinks-main',
+                       mjs: 'node --inspect --preserve-symlinks --preserve-symlinks-main' },
             signal: 'SIGINT' as any, // wrong type definition: signal is of type "string?"
             args,
         });


### PR DESCRIPTION
I'm mixing CommonJS and ESM modules, and the main.js was designed as esm, the filename is main.mjs —and that's exactly the problem. Calling nodemon only considers the .js extension. Therefore, node isn't called with the --inspect parameter.